### PR TITLE
fix: changed default body font size to 17px

### DIFF
--- a/src/themes/default.tsx
+++ b/src/themes/default.tsx
@@ -30,9 +30,9 @@ const typography = {
     fontWeight: headerFontWeight,
   },
   body1: {
-    fontSize: "1rem",
+    fontSize: "1.06rem",
   },
-  fontSize: 20,
+  fontSize: 17,
   fontWeightRegular: 250,
   fontFamily: ["Helvetica", "Arial", "San-Serif"].join(","),
 };


### PR DESCRIPTION
The current theme shows body font-size at 20px. 16px is generally an absolute minimum (and browser default) and 18px is a great start to get big. However, 18px seems to be too large as content gets more in detail. When I have 20px on my full browser I feel like my eyes work too much when reading more lengthy content. 17px seems like the sweet spot. Here's example below 17px, then 20px comparison on core-geth.org/install. Screen shots don't do it justice imo, check inspector on the webpage yourself if you don't feel convinced.
![Screenshot 2020-03-20 02:14:44](https://user-images.githubusercontent.com/10556209/77143671-d8c66f80-6a51-11ea-9952-2a0216384036.png)
![Screenshot 2020-03-20 02:21:59](https://user-images.githubusercontent.com/10556209/77143673-dbc16000-6a51-11ea-96e4-aa733abf4c84.png)

